### PR TITLE
Jupyter Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,23 @@
+FROM openmicroscopy/ome-files-py
+
+RUN pip install datapackage
+RUN pip install jsontableschema
+RUN pip install jsontableschema-pandas
+RUN pip install matplotlib
+RUN pip install pandas
+RUN pip install seaborn
+RUN pip install tabulator
+RUN pip install xlrd
+RUN pip install jupyter
+
+RUN mkdir -p -m 700 /root/.jupyter/ && \
+    echo "c.NotebookApp.ip = '*'" >> /root/.jupyter/jupyter_notebook_config.py
+
+WORKDIR /notebooks
+
+EXPOSE 8888
+
+COPY run_jupyter /bin/
+RUN chmod +x /bin/run_jupyter
+
+CMD ["run_jupyter"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,14 +10,17 @@ RUN pip install tabulator
 RUN pip install xlrd
 RUN pip install jupyter
 
-RUN mkdir -p -m 700 /root/.jupyter/ && \
-    echo "c.NotebookApp.ip = '*'" >> /root/.jupyter/jupyter_notebook_config.py
-
-WORKDIR /notebooks
-
 EXPOSE 8888
 
 COPY run_jupyter /bin/
 RUN chmod +x /bin/run_jupyter
+
+RUN useradd -m jupyter
+USER jupyter
+ENV HOME /home/jupyter
+RUN mkdir -p -m 700 ${HOME}/.jupyter/ && \
+  echo "c.NotebookApp.ip = '*'" >> ${HOME}/.jupyter/jupyter_notebook_config.py
+
+WORKDIR ${HOME}/notebooks
 
 CMD ["run_jupyter"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,8 +6,8 @@ docker run --rm -it -p 8888:8888 cmso-jupyter
 
 Use the URL shown in the startup message, including the token, to access the notebook server from your browser.
 
-For persistence, and to use existing notebooks, you can mount a host directory to `/notebooks` in the container:
+For persistence, and to use existing notebooks, you can mount a host directory to `/home/jupyter/notebooks` in the container:
 
 ```
-docker run --rm -it -p 8888:8888 -v /host/dir:/notebooks cmso-jupyter
+docker run --rm -it -p 8888:8888 -v /host/dir:/home/jupyter/notebooks cmso-jupyter
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,13 @@
+```
+cd docker
+docker build -t cmso-jupyter .
+docker run --rm -it -p 8888:8888 cmso-jupyter
+```
+
+Use the URL shown in the startup message, including the token, to access the notebook server from your browser.
+
+For persistence, and to use existing notebooks, you can mount a host directory to `/notebooks` in the container:
+
+```
+docker run --rm -it -p 8888:8888 -v /host/dir:/notebooks cmso-jupyter
+```

--- a/docker/run_jupyter
+++ b/docker/run_jupyter
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+jupyter notebook --no-browser


### PR DESCRIPTION
Adds the Dockerfile for a Docker image that includes:

* [ome-files-py](https://github.com/ome/ome-files-py)
* Jupyter
* Python dependencies used so far in this repo (pandas, datapackage, etc.). Note that NumPy is included in the inherited ome-files-py Dockerfile.

See `docker/README.md` for usage instructions. I have built the image and pushed it to Docker Hub under my account (until we find a proper location), so you can skip the build step by doing:

```
docker run --rm -it -p 8888:8888 -v /host/dir:/home/jupyter/notebooks simleo/cmso-jupyter
```

Then copy the URL shown in the startup log and paste it in your browser's address bar.

**Note:** ome-files-py runs on Python 2, while the example notebook here uses Python 3. While most of the code appears to be compatible, `jsontableschema.infer` has a bug in Python 2 that causes it to infer all column types as "geojson" (I've filed an issue at https://github.com/frictionlessdata/jsontableschema-py/issues/151).